### PR TITLE
Mostieri/improve docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,10 +37,10 @@ The Ansys Tools Omniverse extension is designed to let you interact
 with Ansys applications via Omniverse, in order to display and post-process
 results from Ansys simulations in the Omniverse environment.
 
-The first product supported is Ansys EnSight_, a full-featured postprocessor 
-and general-purpose data visualization tool, that is capable of handling large simulation 
+The first product supported is Ansys EnSight_, a full-featured postprocessor
+and general-purpose data visualization tool, that is capable of handling large simulation
 datasets from a variety of physics and engineering disciplines.
-It makes use of PyEnSight_, part of the PyAnsys_ ecosystem. PyEnSight is a Python module that 
+It makes use of PyEnSight_, part of the PyAnsys_ ecosystem. PyEnSight is a Python module that
 provides the ability to launch and control an EnSight instance from an external or remote
 Python instance.
 


### PR DESCRIPTION
Some improvements to docs:

1. Brief introduction to EnSight and PyEnSight, pointing to the relevant docs and websites.
2. I copy/pasted the extension docs from the PyEnSight documentation
3. I removed the badges pointing to the PyEnSight actions
4. I also removed the PyPi badge, since as a first cut we don't need to publish the wheel into PyPi anymore