### PR TITLE
Create archive during build and use new ansys action option to only create archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,11 @@ jobs:
         with:
           library-name: ${{ env.PACKAGE_NAME }}
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
+      - name: Remove Dummy Wheel
+        run: |
+          python post_build_cleanup.py
+
+
 
   release:
     name: Release
@@ -88,3 +93,4 @@ jobs:
         uses: ansys/actions/release-github@v8
         with:
           library-name: ${{ env.PACKAGE_NAME }}
+          only-code: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: numpydoc-validation
         exclude: |
           (?x)(
-              tests/ | __init__.py
+              tests/ | __init__.py | post_build_cleanup.py | setup.py
           )
 
   - repo: https://github.com/codespell-project/codespell

--- a/post_build_cleanup.py
+++ b/post_build_cleanup.py
@@ -1,10 +1,12 @@
-import os
 import glob
+import os
+
 
 def clean_dist():
-    for file in glob.glob('dist/*.whl'):
+    for file in glob.glob("dist/*.whl"):
         os.remove(file)
         print(f"Removed {file}")
+
 
 if __name__ == "__main__":
     clean_dist()

--- a/post_build_cleanup.py
+++ b/post_build_cleanup.py
@@ -1,0 +1,10 @@
+import os
+import glob
+
+def clean_dist():
+    for file in glob.glob('dist/*.whl'):
+        os.remove(file)
+        print(f"Removed {file}")
+
+if __name__ == "__main__":
+    clean_dist()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools >= 42.0.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "ansys-tools-omniverse"
 version = "1.0.0.dev0"

--- a/setup.py
+++ b/setup.py
@@ -1,30 +1,42 @@
-from setuptools import setup, find_packages
-from setuptools.command.sdist import sdist as _sdist
-from setuptools.command.bdist_wheel import bdist_wheel as _bdist_wheel
-
 import os
 
-invoked_dir = os.getcwd()
+from setuptools import find_packages, setup
+from setuptools.command.bdist_wheel import bdist_wheel as _bdist_wheel
+from setuptools.command.sdist import sdist as _sdist
+
+description = "Ansys Tools Ominverse Extension"
+HERE = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(HERE, "README.rst"), encoding="utf-8") as f:
+    long_description = f.read()
+
 
 class CustomSdist(_sdist):
     def make_distribution(self):
         # Ensure the 'exts' folder is included in the tar archive
-        self.filelist.files = [f for f in self.filelist.files if f.startswith('exts') or f in ['setup.py', 'pyproject.toml']]
-        for root, dirs, files in os.walk('exts'):
+        self.filelist.files = [
+            f
+            for f in self.filelist.files
+            if f.startswith("exts") or f in ["setup.py", "pyproject.toml"]
+        ]
+        for root, dirs, files in os.walk("exts"):
             for file in files:
                 self.filelist.files.append(os.path.join(root, file))
         super().make_distribution()
 
+
 class CustomBdistWheel(_bdist_wheel):
     def run(self):
         # Create a dummy wheel file to satisfy the build process
-        dist_dir = os.path.join(self.dist_dir, f"{self.distribution.get_name()}-{self.distribution.get_version()}-py3-none-any.whl")
-        with open(dist_dir, 'w') as f:
-            f.write('')
+        dist_dir = os.path.join(
+            self.dist_dir,
+            f"{self.distribution.get_name()}-{self.distribution.get_version()}-py3-none-any.whl",
+        )
+        with open(dist_dir, "w") as f:
+            f.write("")
         print(f"Created dummy wheel file at {dist_dir}")
         # Call the original run method to ensure any other necessary steps are completed
         super().run()
-        
+
         # Remove the dummy wheel file
         if os.path.exists(dist_dir):
             os.remove(dist_dir)
@@ -35,8 +47,10 @@ setup(
     name="ansys-tools-omniverse",
     packages=find_packages(),
     cmdclass={
-        'sdist': CustomSdist,
-        'bdist_wheel': CustomBdistWheel,
+        "sdist": CustomSdist,
+        "bdist_wheel": CustomBdistWheel,
     },
     include_package_data=True,
+    long_description=long_description,
+    long_description_content_type="text/x-rst",  # This is the key line
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,42 @@
+from setuptools import setup, find_packages
+from setuptools.command.sdist import sdist as _sdist
+from setuptools.command.bdist_wheel import bdist_wheel as _bdist_wheel
+
+import os
+
+invoked_dir = os.getcwd()
+
+class CustomSdist(_sdist):
+    def make_distribution(self):
+        # Ensure the 'exts' folder is included in the tar archive
+        self.filelist.files = [f for f in self.filelist.files if f.startswith('exts') or f in ['setup.py', 'pyproject.toml']]
+        for root, dirs, files in os.walk('exts'):
+            for file in files:
+                self.filelist.files.append(os.path.join(root, file))
+        super().make_distribution()
+
+class CustomBdistWheel(_bdist_wheel):
+    def run(self):
+        # Create a dummy wheel file to satisfy the build process
+        dist_dir = os.path.join(self.dist_dir, f"{self.distribution.get_name()}-{self.distribution.get_version()}-py3-none-any.whl")
+        with open(dist_dir, 'w') as f:
+            f.write('')
+        print(f"Created dummy wheel file at {dist_dir}")
+        # Call the original run method to ensure any other necessary steps are completed
+        super().run()
+        
+        # Remove the dummy wheel file
+        if os.path.exists(dist_dir):
+            os.remove(dist_dir)
+            print(f"Removed dummy wheel file at {dist_dir}")
+
+
+setup(
+    name="ansys-tools-omniverse",
+    packages=find_packages(),
+    cmdclass={
+        'sdist': CustomSdist,
+        'bdist_wheel': CustomBdistWheel,
+    },
+    include_package_data=True,
+)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ class CustomSdist(_sdist):
         self.filelist.files = [
             f
             for f in self.filelist.files
-            if f.startswith("exts") or f in ["setup.py", "pyproject.toml"]
+            if f.startswith("exts") or f in ["setup.py", "pyproject.toml", "README.rst"]
         ]
         for root, dirs, files in os.walk("exts"):
             for file in files:


### PR DESCRIPTION
1. When I remove the setup.py script we lost the ability of generating the code archive. The new setup script just creates it containing the exts folder
2. The script also creates a dummy wheel instead of letting the build system attempt to create one. Unfortunately the creation cannot be skipped
3. There is also a post-processing cleanup script that removes the dummy wheel before release is attempted
4. When release is attempted, use the new option "only-code" that I added to the github release action to not attempt to gather docs and wheelhouse when creating the release